### PR TITLE
Telemetry actions filtering

### DIFF
--- a/app/Sources/AppFeature/App.swift
+++ b/app/Sources/AppFeature/App.swift
@@ -11,7 +11,45 @@ struct App: SwiftUI.App {
   @Dependency(\.appTelemetry) var appTelemetry
   let store = Store(initialState: AppReducer.State()) {
     AppReducer()
-    AppTelemetryReducer()
+    AppTelemetryReducer { _, action in
+      switch action {
+      case .contact(.fetchContact): false
+      case .contact(.fetchContactResult(.failure(_))): true
+      case .contact(.fetchContactResult(.success(_))): false
+      case .contact(.view(.linkButtonTapped(_))): true
+      case .contact(.view(.refreshButtonTapped)): true
+      case .contact(.view(.refreshTask)): true
+      case .contact(.view(.task)): false
+      case .feed(.fetchStatuses): false
+      case .feed(.fetchStatusesResult(.failure(_))): true
+      case .feed(.fetchStatusesResult(.success(_))): false
+      case .feed(.status(_, .quickLookItem(.dismiss))): true
+      case .feed(.status(_, .quickLookItem(.presented(_)))): false
+      case .feed(.status(_, .renderText)): false
+      case .feed(.status(_, .textRendered(_))): false
+      case .feed(.status(_, .view(.attachmentTapped(_)))): true
+      case .feed(.status(_, .view(.headerTapped))): true
+      case .feed(.status(_, .view(.linkTapped(_)))): true
+      case .feed(.status(_, .view(.previewCardTapped))): true
+      case .feed(.status(_, .view(.quickLookItemChanged(_)))): true
+      case .feed(.status(_, .view(.textTask))): false
+      case .feed(.view(.refreshButtonTapped)): true
+      case .feed(.view(.refreshTask)): true
+      case .feed(.view(.seeMoreButtonTapped)): true
+      case .feed(.view(.task)): false
+      case .projects(.fetch): false
+      case .projects(.fetchFinished): false
+      case .projects(.fetchInfoResult(.failure(_))): true
+      case .projects(.fetchInfoResult(.success(_))): false
+      case .projects(.fetchProjectsResult(.failure(_))): true
+      case .projects(.fetchProjectsResult(.success(_))): false
+      case .projects(.view(.projectCardTapped(_))): true
+      case .projects(.view(.refreshButtonTapped)): true
+      case .projects(.view(.refreshTask)): true
+      case .projects(.view(.task)): false
+      case .view(.sectionSelected(_)): true
+      }
+    }
   } withDependencies: {
     $0.openURL = .init { [dependencies = $0] url in
       defer {


### PR DESCRIPTION
- [x] Optionally disable telemetry for provided state or action in `AppTelemetryReducer`.
- [x] Filter telemetry actions, as not all actions are worth logging.