### PR TITLE
TCA @Reducer macro

### DIFF
--- a/DarrarskiApp.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DarrarskiApp.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher.git",
       "state" : {
-        "revision" : "b6f62758f21a8c03cd64f4009c037cfa580a256e",
-        "version" : "7.9.1"
+        "revision" : "277f1ab2c6664b19b4a412e32b094b201e2d5757",
+        "version" : "7.10.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "5da6989aae464f324eef5c5b52bdb7974725ab81",
-        "version" : "1.0.0"
+        "revision" : "40773cbaf8d71ed5357f297b1ba4073f5b24faaa",
+        "version" : "1.1.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture.git",
       "state" : {
-        "revision" : "a7c1f799b55ecb418f85094b142565834f7ee7c7",
-        "version" : "1.2.0"
+        "revision" : "57e804f1cc2e17e306620f77deaf36b9f38b0df5",
+        "version" : "1.4.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
       "state" : {
-        "revision" : "ea631ce892687f5432a833312292b80db238186a",
-        "version" : "1.0.0"
+        "revision" : "bb5059bde9022d69ac516803f4f227d8ac967f71",
+        "version" : "1.1.0"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "3efbfba0e4e56c7187cc19137ee16b7c95346b79",
-        "version" : "1.1.0"
+        "revision" : "65fc9e2b62727cacfab9fc60d580c284a4b9308c",
+        "version" : "1.1.1"
       }
     },
     {
@@ -88,6 +88,15 @@
       "state" : {
         "revision" : "d1e45f3e1eee2c9193f5369fa9d70a6ddad635e8",
         "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax",
+      "state" : {
+        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
+        "version" : "509.0.2"
       }
     },
     {
@@ -113,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ActuallyTaylor/SwiftHTMLToMarkdown.git",
       "state" : {
-        "revision" : "88d011155041b84efd333505c6fcbcaa4fda3362",
-        "version" : "1.1.0"
+        "revision" : "d533b9cb47a8defaa8d9432fad20ecf5964c0668",
+        "version" : "1.1.1"
       }
     },
     {
@@ -140,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation",
       "state" : {
-        "revision" : "6eb293c49505d86e9e24232cb6af6be7fff93bd5",
-        "version" : "1.0.2"
+        "revision" : "a3aa5d46e8bf174d773d23b030f1c103999398ac",
+        "version" : "1.1.0"
       }
     },
     {

--- a/DarrarskiApp.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DarrarskiApp.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "40773cbaf8d71ed5357f297b1ba4073f5b24faaa",
-        "version" : "1.1.0"
+        "revision" : "ed7facdd4a361514b46e3bbc6238cd41c84be4ec",
+        "version" : "1.1.1"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture.git",
       "state" : {
-        "revision" : "57e804f1cc2e17e306620f77deaf36b9f38b0df5",
-        "version" : "1.4.0"
+        "revision" : "eddc1869b37ce42e3b34e72b1e1355d049e73970",
+        "version" : "1.4.2"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "4e1eb6e28afe723286d8cc60611237ffbddba7c5",
-        "version" : "1.0.0"
+        "revision" : "3870cfc79dd0d5a2e9f0a302e13ad145a63cb8f7",
+        "version" : "1.1.0"
       }
     },
     {

--- a/app/Sources/AppFeature/App.swift
+++ b/app/Sources/AppFeature/App.swift
@@ -23,17 +23,17 @@ struct App: SwiftUI.App {
       case .feed(.fetchStatuses): false
       case .feed(.fetchStatusesResult(.failure(_))): true
       case .feed(.fetchStatusesResult(.success(_))): false
-      case .feed(.status(_, .quickLookItem(.dismiss))): true
-      case .feed(.status(_, .quickLookItem(.presented(_)))): false
-      case .feed(.status(_, .renderText)): false
-      case .feed(.status(_, .textRendered(.failure(_)))): true
-      case .feed(.status(_, .textRendered(.success(_)))): false
-      case .feed(.status(_, .view(.attachmentTapped(_)))): true
-      case .feed(.status(_, .view(.headerTapped))): true
-      case .feed(.status(_, .view(.linkTapped(_)))): true
-      case .feed(.status(_, .view(.previewCardTapped))): true
-      case .feed(.status(_, .view(.quickLookItemChanged(_)))): true
-      case .feed(.status(_, .view(.textTask))): false
+      case .feed(.status(.element(_, .quickLookItem(.dismiss)))): true
+      case .feed(.status(.element(_, .quickLookItem(.presented(_))))): false
+      case .feed(.status(.element(_, .renderText))): false
+      case .feed(.status(.element(_, .textRendered(.failure(_))))): true
+      case .feed(.status(.element(_, .textRendered(.success(_))))): false
+      case .feed(.status(.element(_, .view(.attachmentTapped(_))))): true
+      case .feed(.status(.element(_, .view(.headerTapped)))): true
+      case .feed(.status(.element(_, .view(.linkTapped(_))))): true
+      case .feed(.status(.element(_, .view(.previewCardTapped)))): true
+      case .feed(.status(.element(_, .view(.quickLookItemChanged(_))))): true
+      case .feed(.status(.element(_, .view(.textTask)))): false
       case .feed(.view(.refreshButtonTapped)): true
       case .feed(.view(.refreshTask)): true
       case .feed(.view(.seeMoreButtonTapped)): true

--- a/app/Sources/AppFeature/AppReducer.swift
+++ b/app/Sources/AppFeature/AppReducer.swift
@@ -5,7 +5,7 @@ import Foundation
 import ProjectsFeature
 
 @Reducer
-public struct AppReducer {
+public struct AppReducer: Reducer, Sendable {
   public struct State: Equatable {
     public enum Section: Equatable, CaseIterable {
       case contact

--- a/app/Sources/AppFeature/AppReducer.swift
+++ b/app/Sources/AppFeature/AppReducer.swift
@@ -4,7 +4,8 @@ import FeedFeature
 import Foundation
 import ProjectsFeature
 
-public struct AppReducer: Reducer {
+@Reducer
+public struct AppReducer {
   public struct State: Equatable {
     public enum Section: Equatable, CaseIterable {
       case contact
@@ -30,13 +31,14 @@ public struct AppReducer: Reducer {
     var selectedSection: Section
   }
 
-  public enum Action: Equatable {
+  public enum Action {
     case contact(ContactReducer.Action)
     case feed(FeedReducer.Action)
     case projects(ProjectsReducer.Action)
     case view(View)
 
-    public enum View: Equatable {
+    @CasePathable
+    public enum View {
       case sectionSelected(State.Section?)
     }
   }
@@ -44,13 +46,13 @@ public struct AppReducer: Reducer {
   public init() {}
 
   public var body: some ReducerOf<Self> {
-    Scope(state: \.contact, action: /Action.contact) {
+    Scope(state: \.contact, action: \.contact) {
       ContactReducer()
     }
-    Scope(state: \.feed, action: /Action.feed) {
+    Scope(state: \.feed, action: \.feed) {
       FeedReducer()
     }
-    Scope(state: \.projects, action: /Action.projects) {
+    Scope(state: \.projects, action: \.projects) {
       ProjectsReducer()
     }
 

--- a/app/Sources/AppFeature/AppReducer.swift
+++ b/app/Sources/AppFeature/AppReducer.swift
@@ -56,7 +56,7 @@ public struct AppReducer: Reducer, Sendable {
       ProjectsReducer()
     }
 
-    Reduce { state, action in
+    Reduce<State, Action> { state, action in
       switch action {
       case .contact(_), .feed(_), .projects(_):
         return .none

--- a/app/Sources/AppFeature/AppTelemetryReducer.swift
+++ b/app/Sources/AppFeature/AppTelemetryReducer.swift
@@ -4,7 +4,8 @@ import TelemetryClient
 
 typealias AppTelemetryReducerOf<R: Reducer> = AppTelemetryReducer<R.State, R.Action>
 
-struct AppTelemetryReducer<State, Action>: Reducer, Sendable {
+@Reducer
+struct AppTelemetryReducer<State, Action>: Sendable {
   typealias IsEnabled = @Sendable (State, Action) -> Bool
 
   init(enabled: @escaping IsEnabled = { _, _ in true }) {

--- a/app/Sources/AppFeature/AppTelemetryReducer.swift
+++ b/app/Sources/AppFeature/AppTelemetryReducer.swift
@@ -5,7 +5,7 @@ import TelemetryClient
 typealias AppTelemetryReducerOf<R: Reducer> = AppTelemetryReducer<R.State, R.Action>
 
 @Reducer
-struct AppTelemetryReducer<State, Action>: Sendable {
+struct AppTelemetryReducer<State, Action>: Reducer, Sendable {
   typealias IsEnabled = @Sendable (State, Action) -> Bool
 
   init(enabled: @escaping IsEnabled = { _, _ in true }) {

--- a/app/Sources/AppShared/_Concurrency.swift
+++ b/app/Sources/AppShared/_Concurrency.swift
@@ -1,0 +1,2 @@
+// NB: This silences warnings about non-sendable KeyPaths
+extension KeyPath: @unchecked Sendable {}

--- a/app/Sources/ContactFeature/ContactReducer.swift
+++ b/app/Sources/ContactFeature/ContactReducer.swift
@@ -1,7 +1,8 @@
 import ComposableArchitecture
 import Foundation
 
-public struct ContactReducer: Reducer, Sendable {
+@Reducer
+public struct ContactReducer: Sendable {
   public struct State: Equatable {
     public init(
       contact: Contact? = nil,
@@ -15,12 +16,13 @@ public struct ContactReducer: Reducer, Sendable {
     var isLoading: Bool
   }
 
-  public enum Action: Equatable, Sendable {
+  public enum Action: Sendable {
     case fetchContact
-    case fetchContactResult(TaskResult<Contact>)
+    case fetchContactResult(Result<Contact, Error>)
     case view(View)
 
-    public enum View: Equatable, Sendable {
+    @CasePathable
+    public enum View: Sendable {
       case linkButtonTapped(Contact.Link)
       case refreshButtonTapped
       case refreshTask
@@ -43,7 +45,7 @@ public struct ContactReducer: Reducer, Sendable {
         state.isLoading = true
         return .run { send in
           try await clock.sleep(for: .seconds(0.5))
-          let result = await TaskResult {
+          let result = await Result {
             try await contactProvider.fetch()
           }
           await send(.fetchContactResult(result))

--- a/app/Sources/ContactFeature/ContactReducer.swift
+++ b/app/Sources/ContactFeature/ContactReducer.swift
@@ -37,7 +37,7 @@ public struct ContactReducer: Reducer, Sendable {
   @Dependency(\.openURL) var openURL
 
   public var body: some ReducerOf<Self> {
-    Reduce { state, action in
+    Reduce<State, Action> { state, action in
       enum CancelId { case fetchGravatar }
 
       switch action {

--- a/app/Sources/ContactFeature/ContactReducer.swift
+++ b/app/Sources/ContactFeature/ContactReducer.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import Foundation
 
 @Reducer
-public struct ContactReducer: Sendable {
+public struct ContactReducer: Reducer, Sendable {
   public struct State: Equatable {
     public init(
       contact: Contact? = nil,

--- a/app/Sources/FeedFeature/FeedReducer.swift
+++ b/app/Sources/FeedFeature/FeedReducer.swift
@@ -41,7 +41,7 @@ public struct FeedReducer: Reducer, Sendable {
   static let mastodonAccountURL = URL(string: "https://mastodon.social/@darrarski")!
 
   public var body: some ReducerOf<Self> {
-    Reduce { state, action in
+    Reduce<State, Action> { state, action in
       enum CancelId { case fetchStatuses }
 
       switch action {

--- a/app/Sources/FeedFeature/FeedReducer.swift
+++ b/app/Sources/FeedFeature/FeedReducer.swift
@@ -20,7 +20,7 @@ public struct FeedReducer: Sendable {
   public enum Action: Sendable {
     case fetchStatuses
     case fetchStatusesResult(Result<[Mastodon.Status], Error>)
-    case status(id: StatusReducer.State.ID, action: StatusReducer.Action)
+    case status(IdentifiedActionOf<StatusReducer>)
     case view(View)
 
     @CasePathable
@@ -73,7 +73,7 @@ public struct FeedReducer: Sendable {
         }
         return .none
 
-      case .status(_, _):
+      case .status(_):
         return .none
 
       case .view(.refreshButtonTapped):

--- a/app/Sources/FeedFeature/FeedReducer.swift
+++ b/app/Sources/FeedFeature/FeedReducer.swift
@@ -3,7 +3,7 @@ import Foundation
 import Mastodon
 
 @Reducer
-public struct FeedReducer: Sendable {
+public struct FeedReducer: Reducer, Sendable {
   public struct State: Equatable {
     public init(
       statuses: IdentifiedArrayOf<StatusReducer.State> = [],

--- a/app/Sources/FeedFeature/StatusReducer.swift
+++ b/app/Sources/FeedFeature/StatusReducer.swift
@@ -2,7 +2,8 @@ import ComposableArchitecture
 import Foundation
 import Mastodon
 
-public struct StatusReducer: Reducer, Sendable {
+@Reducer
+public struct StatusReducer: Sendable {
   public struct State: Equatable, Sendable, Identifiable {
     public init(
       status: Status,
@@ -35,13 +36,14 @@ public struct StatusReducer: Reducer, Sendable {
     }
   }
 
-  public enum Action: Equatable, Sendable {
+  public enum Action: Sendable {
     case quickLookItem(PresentationAction<Never>)
     case renderText
-    case textRendered(TaskResult<AttributedString>)
+    case textRendered(Result<AttributedString, Error>)
     case view(View)
 
-    public enum View: Equatable, Sendable {
+    @CasePathable
+    public enum View: Sendable {
       case attachmentTapped(MediaAttachment.ID)
       case headerTapped
       case linkTapped(URL)
@@ -65,7 +67,7 @@ public struct StatusReducer: Reducer, Sendable {
       case .renderText:
         let html = state.displayStatus.content
         return .run { send in
-          let result = await TaskResult<AttributedString> { try render(html) }
+          let result = Result { try render(html) }
           await send(.textRendered(result))
         }
 
@@ -122,7 +124,7 @@ public struct StatusReducer: Reducer, Sendable {
         return .none
       }
     }
-    .ifLet(\.$quickLookItem, action: /Action.quickLookItem) {
+    .ifLet(\.$quickLookItem, action: \.quickLookItem) {
       EmptyReducer()
     }
   }

--- a/app/Sources/FeedFeature/StatusReducer.swift
+++ b/app/Sources/FeedFeature/StatusReducer.swift
@@ -59,7 +59,7 @@ public struct StatusReducer: Reducer, Sendable {
   @Dependency(\.statusTextRenderer) var render
 
   public var body: some ReducerOf<Self> {
-    Reduce { state, action in
+    Reduce<State, Action> { state, action in
       switch action {
       case .quickLookItem(_):
         return .none

--- a/app/Sources/FeedFeature/StatusReducer.swift
+++ b/app/Sources/FeedFeature/StatusReducer.swift
@@ -3,7 +3,7 @@ import Foundation
 import Mastodon
 
 @Reducer
-public struct StatusReducer: Sendable {
+public struct StatusReducer: Reducer, Sendable {
   public struct State: Equatable, Sendable, Identifiable {
     public init(
       status: Status,

--- a/app/Sources/ProjectsFeature/ProjectsReducer.swift
+++ b/app/Sources/ProjectsFeature/ProjectsReducer.swift
@@ -1,7 +1,7 @@
 import ComposableArchitecture
 
 @Reducer
-public struct ProjectsReducer: Sendable {
+public struct ProjectsReducer: Reducer, Sendable {
   public struct State: Equatable {
     public init(
       info: ProjectsInfo? = nil,

--- a/app/Sources/ProjectsFeature/ProjectsReducer.swift
+++ b/app/Sources/ProjectsFeature/ProjectsReducer.swift
@@ -1,6 +1,7 @@
 import ComposableArchitecture
 
-public struct ProjectsReducer: Reducer, Sendable {
+@Reducer
+public struct ProjectsReducer: Sendable {
   public struct State: Equatable {
     public init(
       info: ProjectsInfo? = nil,
@@ -20,14 +21,15 @@ public struct ProjectsReducer: Reducer, Sendable {
     }
   }
 
-  public enum Action: Equatable, Sendable {
+  public enum Action: Sendable {
     case fetch
     case fetchFinished
-    case fetchInfoResult(TaskResult<ProjectsInfo>)
-    case fetchProjectsResult(TaskResult<[Project]>)
+    case fetchInfoResult(Result<ProjectsInfo, Error>)
+    case fetchProjectsResult(Result<[Project], Error>)
     case view(View)
 
-    public enum View: Equatable, Sendable {
+    @CasePathable
+    public enum View: Sendable {
       case projectCardTapped(Project.ID)
       case refreshButtonTapped
       case refreshTask
@@ -50,10 +52,10 @@ public struct ProjectsReducer: Reducer, Sendable {
         state.isLoading = true
         return .run { send in
           try await clock.sleep(for: .seconds(0.5))
-          await send(.fetchInfoResult(TaskResult {
+          await send(.fetchInfoResult(Result {
             try await projectsProvider.fetchInfo()
           }))
-          await send(.fetchProjectsResult(TaskResult {
+          await send(.fetchProjectsResult(Result {
             try await projectsProvider.fetchProjects()
           }))
           await send(.fetchFinished)

--- a/app/Sources/ProjectsFeature/ProjectsReducer.swift
+++ b/app/Sources/ProjectsFeature/ProjectsReducer.swift
@@ -44,7 +44,7 @@ public struct ProjectsReducer: Reducer, Sendable {
   @Dependency(\.openURL) var openURL
 
   public var body: some ReducerOf<Self> {
-    Reduce { state, action in
+    Reduce<State, Action> { state, action in
       enum CancelId { case fetch }
 
       switch action {

--- a/app/Tests/AppFeatureTests/AppTelemetryReducerTests.swift
+++ b/app/Tests/AppFeatureTests/AppTelemetryReducerTests.swift
@@ -97,8 +97,8 @@ final class AppTelemetryReducerTests: XCTestCase {
     struct ExampleReducer: Reducer {
       struct State: Equatable {}
 
-      enum Action: Equatable {
-        case first(TaskResult<String>)
+      enum Action {
+        case first(Result<String, Error>)
         case second(NSError, NSError, NSError)
       }
 

--- a/app/Tests/ContactFeatureTests/ContactReducerTests.swift
+++ b/app/Tests/ContactFeatureTests/ContactReducerTests.swift
@@ -17,7 +17,7 @@ final class ContactReducerTests: XCTestCase {
       $0.isLoading = true
     }
     await clock.advance(by: .seconds(0.5))
-    await store.receive(.fetchContactResult(.success(.preview))) {
+    await store.receive(\.fetchContactResult.success) {
       $0.isLoading = false
       $0.contact = .preview
     }
@@ -35,7 +35,7 @@ final class ContactReducerTests: XCTestCase {
     await store.send(.fetchContact) {
       $0.isLoading = true
     }
-    await store.receive(.fetchContactResult(.failure(error))) {
+    await store.receive(\.fetchContactResult.failure) {
       $0.isLoading = false
     }
   }
@@ -50,7 +50,7 @@ final class ContactReducerTests: XCTestCase {
     store.exhaustivity = .off
 
     await store.send(.view(.task))
-    await store.receive(.fetchContact)
+    await store.receive(\.fetchContact)
   }
 
   func testViewRefreshTask() async {
@@ -63,7 +63,7 @@ final class ContactReducerTests: XCTestCase {
     store.exhaustivity = .off
 
     await store.send(.view(.refreshTask))
-    await store.receive(.fetchContact)
+    await store.receive(\.fetchContact)
 
   }
 
@@ -77,7 +77,7 @@ final class ContactReducerTests: XCTestCase {
     store.exhaustivity = .off
 
     await store.send(.view(.refreshButtonTapped))
-    await store.receive(.fetchContact)
+    await store.receive(\.fetchContact)
   }
 
   func testViewLinkButtonTapped() async {

--- a/app/Tests/FeedFeatureTests/FeedReducerTests.swift
+++ b/app/Tests/FeedFeatureTests/FeedReducerTests.swift
@@ -30,7 +30,7 @@ final class FeedReducerTests: XCTestCase {
         excludeReplies: true
       )])
     }
-    await store.receive(.fetchStatusesResult(.success(statuses))) {
+    await store.receive(\.fetchStatusesResult.success) {
       $0.isLoading = false
       $0.statuses = .init(
         uniqueElements: statuses.map { StatusReducer.State(status: $0) }
@@ -50,7 +50,7 @@ final class FeedReducerTests: XCTestCase {
     await store.send(.fetchStatuses) {
       $0.isLoading = true
     }
-    await store.receive(.fetchStatusesResult(.failure(error))) {
+    await store.receive(\.fetchStatusesResult.failure) {
       $0.isLoading = false
     }
   }
@@ -65,7 +65,7 @@ final class FeedReducerTests: XCTestCase {
     store.exhaustivity = .off
 
     await store.send(.view(.task))
-    await store.receive(.fetchStatuses)
+    await store.receive(\.fetchStatuses)
   }
 
   func testViewRefreshTask() async {
@@ -78,7 +78,7 @@ final class FeedReducerTests: XCTestCase {
     store.exhaustivity = .off
 
     await store.send(.view(.refreshTask))
-    await store.receive(.fetchStatuses)
+    await store.receive(\.fetchStatuses)
   }
 
   func testViewRefreshButtonTapped() async {
@@ -91,7 +91,7 @@ final class FeedReducerTests: XCTestCase {
     store.exhaustivity = .off
 
     await store.send(.view(.refreshButtonTapped))
-    await store.receive(.fetchStatuses)
+    await store.receive(\.fetchStatuses)
   }
 
   func testViewSeeMoreButtonTapped() async {

--- a/app/Tests/FeedFeatureTests/StatusReducerTests.swift
+++ b/app/Tests/FeedFeatureTests/StatusReducerTests.swift
@@ -239,9 +239,9 @@ final class StatusReducerTests: XCTestCase {
     }
 
     await store.send(.view(.textTask))
-    await store.receive(.renderText)
+    await store.receive(\.renderText)
     XCTAssertNoDifference(didRender.value, [status.content])
-    await store.receive(.textRendered(.success(renderedText))) {
+    await store.receive(\.textRendered.success) {
       $0.text = renderedText
     }
 
@@ -261,8 +261,8 @@ final class StatusReducerTests: XCTestCase {
     }
 
     await store.send(.view(.textTask))
-    await store.receive(.renderText)
-    await store.receive(.textRendered(.failure(failure))) {
+    await store.receive(\.renderText)
+    await store.receive(\.textRendered.failure) {
       $0.text = AttributedString(status.content)
     }
   }

--- a/app/Tests/ProjectsFeatureTests/ProjectsReducerTests.swift
+++ b/app/Tests/ProjectsFeatureTests/ProjectsReducerTests.swift
@@ -18,13 +18,13 @@ final class ProjectsReducerTests: XCTestCase {
       $0.isLoading = true
     }
     await clock.advance(by: .seconds(0.5))
-    await store.receive(.fetchInfoResult(.success(.preview))) {
+    await store.receive(\.fetchInfoResult.success) {
       $0.info = .preview
     }
-    await store.receive(.fetchProjectsResult(.success(.preview))) {
+    await store.receive(\.fetchProjectsResult.success) {
       $0.groups = .init(groupingByYear: .init(uniqueElements: [Project].preview))
     }
-    await store.receive(.fetchFinished) {
+    await store.receive(\.fetchFinished) {
       $0.isLoading = false
     }
   }
@@ -42,11 +42,11 @@ final class ProjectsReducerTests: XCTestCase {
     await store.send(.fetch) {
       $0.isLoading = true
     }
-    await store.receive(.fetchInfoResult(.failure(error)))
-    await store.receive(.fetchProjectsResult(.success(.preview))) {
+    await store.receive(\.fetchInfoResult.failure)
+    await store.receive(\.fetchProjectsResult.success) {
       $0.groups = .init(groupingByYear: .init(uniqueElements: [Project].preview))
     }
-    await store.receive(.fetchFinished) {
+    await store.receive(\.fetchFinished) {
       $0.isLoading = false
     }
   }
@@ -64,11 +64,11 @@ final class ProjectsReducerTests: XCTestCase {
     await store.send(.fetch) {
       $0.isLoading = true
     }
-    await store.receive(.fetchInfoResult(.success(.preview))) {
+    await store.receive(\.fetchInfoResult.success) {
       $0.info = .preview
     }
-    await store.receive(.fetchProjectsResult(.failure(error)))
-    await store.receive(.fetchFinished) {
+    await store.receive(\.fetchProjectsResult.failure)
+    await store.receive(\.fetchFinished) {
       $0.isLoading = false
     }
   }
@@ -84,7 +84,7 @@ final class ProjectsReducerTests: XCTestCase {
     store.exhaustivity = .off
 
     await store.send(.view(.refreshButtonTapped))
-    await store.receive(.fetch)
+    await store.receive(\.fetch)
   }
 
   func testViewRefreshTask() async {
@@ -98,7 +98,7 @@ final class ProjectsReducerTests: XCTestCase {
     store.exhaustivity = .off
 
     await store.send(.view(.refreshTask))
-    await store.receive(.fetch)
+    await store.receive(\.fetch)
   }
 
   func testViewTask() async {
@@ -112,7 +112,7 @@ final class ProjectsReducerTests: XCTestCase {
     store.exhaustivity = .off
 
     await store.send(.view(.task))
-    await store.receive(.fetch)
+    await store.receive(\.fetch)
   }
 
   func testViewProjectCardTapped() async {

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -36,3 +36,6 @@ if [[ $CI_WORKFLOW == "Deploy" ]]; then
   # Use TelemetryDeckAppID secret from workflow environment variable
   echo "${TelemetryDeckAppID}" > ../app/Sources/AppFeature/Secrets/TelemetryDeckAppID
 fi
+
+# Skip validation of third-party swift macros
+defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES


### PR DESCRIPTION
- [x] Update Composable Architecture to v1.4.2
- [x] Migrate to `@Reducer` macro
- [x] Use `CaseKeyPath` with TestStore.receive
- [x] Use `IdentifiedAction` in `FeedReducer`
- [x] Silence warnings about non-sendable KeyPaths