### PR TITLE
Feed rendering improvements

### DIFF
--- a/Projects/App/AppFeature/Sources/App.swift
+++ b/Projects/App/AppFeature/Sources/App.swift
@@ -33,7 +33,7 @@ struct App: SwiftUI.App {
       case .feed(.status(.element(_, .view(.linkTapped(_))))): true
       case .feed(.status(.element(_, .view(.previewCardTapped)))): true
       case .feed(.status(.element(_, .view(.quickLookItemChanged(_))))): true
-      case .feed(.status(.element(_, .view(.textTask)))): false
+      case .feed(.status(.element(_, .view(.textSourceChanged)))): false
       case .feed(.view(.refreshButtonTapped)): true
       case .feed(.view(.refreshTask)): true
       case .feed(.view(.seeMoreButtonTapped)): true

--- a/Projects/App/FeedFeature/Sources/FeedReducer.swift
+++ b/Projects/App/FeedFeature/Sources/FeedReducer.swift
@@ -65,8 +65,12 @@ public struct FeedReducer: Reducer, Sendable {
         state.isLoading = false
         switch result {
         case .success(let statuses):
-          state.statuses = .init(
-            uniqueElements: statuses.map { StatusReducer.State(status:$0) }
+          state.statuses = IdentifiedArray(
+            uniqueElements: statuses.map { status in
+              var state = state.statuses[id: status.id] ?? StatusReducer.State(status: status)
+              state.status = status
+              return state
+            }
           )
 
         case .failure(_):

--- a/Projects/App/FeedFeature/Sources/StatusView.swift
+++ b/Projects/App/FeedFeature/Sources/StatusView.swift
@@ -42,8 +42,9 @@ public struct StatusView: View {
     Text(text)
       .redacted(reason: isPlaceholder ? .placeholder : [])
       .disabled(isPlaceholder)
-      .onChange(of: isPlaceholder, initial: true) { _, isPlaceholder in
-        if isPlaceholder { send(.textTask) }
+      .onChange(of: store.textSource, initial: true) { old, new in
+        guard old != new || store.text == nil else { return }
+        send(.textSourceChanged)
       }
       .environment(\.openURL, OpenURLAction { url in
         send(.linkTapped(url))

--- a/Projects/App/FeedFeature/Tests/StatusReducerTests.swift
+++ b/Projects/App/FeedFeature/Tests/StatusReducerTests.swift
@@ -223,14 +223,12 @@ final class StatusReducerTests: XCTestCase {
       }
     }
 
-    await store.send(.view(.textTask))
+    await store.send(.view(.textSourceChanged))
     await store.receive(\.renderText)
     expectNoDifference(didRender.value, [status.content])
     await store.receive(\.textRendered.success) {
       $0.text = renderedText
     }
-
-    await store.send(.view(.textTask))
   }
 
   @MainActor func testTextRenderingFailure() async {
@@ -245,7 +243,7 @@ final class StatusReducerTests: XCTestCase {
       $0.statusTextRenderer.render = { _ in throw failure }
     }
 
-    await store.send(.view(.textTask))
+    await store.send(.view(.textSourceChanged))
     await store.receive(\.renderText)
     await store.receive(\.textRendered.failure) {
       $0.text = AttributedString(status.content)

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The project is integrated with [Xcode Cloud](https://developer.apple.com/xcode-c
 
 ## 🛠 Develop
 
-- Use Xcode (version ≥ 15.4).
+- Use Xcode (version ≥ 16.0).
 - Clone the repository or create a fork & clone it.
 - Run `setup_for_development.sh` script to generate Xcode workspace and set everything up for development:
     ```sh


### PR DESCRIPTION
## Summary

This change improves Feed screen rendering and scrolling performance.

## What was done

- [x] Preserve `StatusReducer.State` when reloading statuses.
- [x] Update status rendering. Only render HTML to AttributedString when the HTML intended to be displayed changes for the status displayed on the screen.
